### PR TITLE
Fix learnt questions triggering an exam reset

### DIFF
--- a/src/views/Exam/Exam.tsx
+++ b/src/views/Exam/Exam.tsx
@@ -57,7 +57,8 @@ export const Exam = () => {
 
   useEffect(() => {
     onReset();
-  }, [onReset]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [questionsCount, subjectData, filterOutLearnt]);
 
   const onSubmit = () => {
     setCompleted(true);


### PR DESCRIPTION
A little bug found 🙈 `onReset` depends on `learntQuestions`, ofc resetting should not happen if these change.